### PR TITLE
MacOS support

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Verify nix config
         run: |
           if ! egrep -q "^substituters = https://cache.nixos.org https://nixbuild.cachix.org$" "$HOME/.config/nix/nix.conf"; then
-            echo "Invalid substiturers config"
+            echo "Invalid substituters config"
             exit 1
           fi
       - name: Push to Cachix

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,12 +4,15 @@ name: CI/CD
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: ./
         with:
-          nix_archives_url: https://github.com/nixbuild/nix-quick-install-action/releases/download/v2
+          nix_archives_url: https://github.com/nixbuild/nix-quick-install-action/releases/download/v0
           nix_version: 3.0pre20200829_f156513
           nix_conf: experimental-features = nix-command flakes
       - name: Build nix archives
@@ -19,25 +22,26 @@ jobs:
           echo "::set-output name=result::$(readlink result)"
       - uses: actions/upload-artifact@v2
         with:
-          name: nix-archives
+          name: nix-archives-${{ matrix.os }}
           path: ${{ steps.build-nix-archives.outputs.result }}/
 
   test-nix:
-    runs-on: ubuntu-latest
     needs: build
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         nix_version:
           - 3.0pre20200829_f156513
           - 2.3.7
           - 2.2.2
           - 2.1.3
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         id: nix-archives
         with:
-          name: nix-archives
+          name: nix-archives-${{ matrix.os }}
       - uses: ./
         with:
           nix_archives_url: file://${{steps.nix-archives.outputs.download-path}}
@@ -46,22 +50,27 @@ jobs:
         run: nix-build -v --version
 
   test-cachix:
-    runs-on: ubuntu-latest
     needs: build
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         nix_version:
           - 2.3.7
           - 2.2.2
         include:
-          - nix_version: 3.0pre20200829_f156513
+          - os: ubuntu-latest
+            nix_version: 3.0pre20200829_f156513
             nix_conf: experimental-features = nix-command flakes
+          - os: macos-latest
+            nix_version: 3.0pre20200829_f156513
+            nix_conf: experimental-features = nix-command flakes
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         id: nix-archives
         with:
-          name: nix-archives
+          name: nix-archives-${{ matrix.os }}
       - uses: ./
         with:
           nix_archives_url: file://${{steps.nix-archives.outputs.download-path}}
@@ -83,7 +92,6 @@ jobs:
           dd if=/dev/urandom of=random count=1
           cachix push nixbuild "$(nix add-to-store random)"
 
-
   release:
     runs-on: ubuntu-latest
     needs:
@@ -94,17 +102,21 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
-        id: nix-archives
         with:
-          name: nix-archives
+          name: nix-archives-ubuntu-latest
+          path: /tmp/archives
+      - uses: actions/download-artifact@v2
+        with:
+          name: nix-archives-macos-latest
+          path: /tmp/archives
       - uses: ./
         with:
-          nix_archives_url: file://${{steps.nix-archives.outputs.download-path}}
+          nix_archives_url: file:///tmp/archives
           nix_version: 3.0pre20200829_f156513
           nix_conf: experimental-features = nix-command flakes
       - name: Build release script
         run: nix build .#release
       - name: Release if needed
-        run: ./result/bin/release ${{steps.nix-archives.outputs.download-path}} ./RELEASE
+        run: ./result/bin/release /tmp/archives ./RELEASE
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,26 +25,6 @@ jobs:
           name: nix-archives
           path: ${{ steps.build-nix-archives.outputs.result }}/
 
-  build-with-cachix:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./
-        with:
-          nix_archives_url: https://github.com/nixbuild/nix-quick-install-action/releases/download/v2
-          nix_version: 3.0pre20200829_f156513
-          nix_conf: experimental-features = nix-command flakes
-      - uses: nixbuild/nixbuild-action@v1
-        with:
-          nixbuild_ssh_key: ${{ secrets.nixbuild_ssh_key }}
-      - uses: cachix/cachix-action@v6
-        with:
-          name: nixbuild
-          signingKey: ${{ secrets.cachix_signing_key }}
-      - name: Build nix archives
-        id: build-nix-archives
-        run: nix build -v .#nix-archives
-
   test-nix:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,9 +12,6 @@ jobs:
           nix_archives_url: https://github.com/nixbuild/nix-quick-install-action/releases/download/v2
           nix_version: 3.0pre20200829_f156513
           nix_conf: experimental-features = nix-command flakes
-      - uses: nixbuild/nixbuild-action@v1
-        with:
-          nixbuild_ssh_key: ${{ secrets.nixbuild_ssh_key }}
       - name: Build nix archives
         id: build-nix-archives
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -78,6 +78,7 @@ jobs:
             exit 1
           fi
       - name: Push to Cachix
+        if: github.repository_owner == 'nixbuild'
         run: |
           dd if=/dev/urandom of=random count=1
           cachix push nixbuild "$(nix add-to-store random)"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -89,7 +89,7 @@ jobs:
             exit 1
           fi
       - name: Push to Cachix
-        if: github.repository_owner == 'nixbuild'
+        if: github.event_name == 'push' && github.repository_owner == 'nixbuild'
         run: |
           dd if=/dev/urandom of=random count=1
           cachix push nixbuild "$(nix add-to-store random)"
@@ -100,7 +100,7 @@ jobs:
       - build
       - test-nix
       - test-cachix
-    if: github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2


### PR DESCRIPTION
I was expecting this to be a lot less work than it turned out to be, but oh well. 🙃 It seems to work well, with ~4s as the lowest time taken by the install in my testing, mostly taken up by the APFS volume step unfortunately.

Some motivation is also in the individual commit messages.

I've created this as a draft because of the FIXME, which is in place because adding a platform is a chicken-egg problem. I've prepared nix-3.0pre builds of Linux and macOS at that URL, but I'm not sure how to break the chain and make this mergeable yet.

One thing I tried was to switch back to cachix/install-nix-action for the bootstrap, but getting flakes support to work on macOS is currently an issue there too.