### PR TITLE
Add Nix build: 2.4pre20210317_8a5203d

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         nix_version:
+          - 2.4pre20210317_8a5203d
           - 2.4pre20201205_a5d85d0
           - 3.0pre20200829_f156513
           - 2.3.10
@@ -59,12 +60,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         nix_version:
+          - 2.4pre20210317_8a5203d
           - 2.4pre20201205_a5d85d0
           - 3.0pre20200829_f156513
           - 2.3.10
           - 2.3.7
           - 2.2.2
         include:
+          - nix_version: 2.4pre20210317_8a5203d
+            nix_conf: experimental-features = nix-command flakes
           - nix_version: 2.4pre20201205_a5d85d0
             nix_conf: experimental-features = nix-command flakes
           - nix_version: 3.0pre20200829_f156513
@@ -117,7 +121,7 @@ jobs:
       - uses: ./
         with:
           nix_archives_url: file:///tmp/archives
-          nix_version: 2.4pre20201205_a5d85d0
+          nix_version: 2.4pre20210317_8a5203d
           nix_conf: experimental-features = nix-command flakes
       - name: Build release script
         run: nix build .#release

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1600209923,
-        "narHash": "sha256-zoOWauTliFEjI++esk6Jzk7QO5EKpddWXQm9yQK24iM=",
+        "lastModified": 1614513358,
+        "narHash": "sha256-LakhOx3S1dRjnh0b5Dg3mbZyH0ToC9I8Y2wKSkBaTzU=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cd06d3c1df6879c9e41cb2c33113df10566c760",
+        "rev": "5466c5bbece17adaab2d82fae80b46e807611bf3",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1613984754,
-        "narHash": "sha256-CGsiTsuRq0fWwWRzzn0a+MxO2EUJT3M3qt0/n9RUjMY=",
+        "lastModified": 1616685645,
+        "narHash": "sha256-WJZKV/4nSovZN7y31Bgc2zIxn5hJGeYbIEpf+EJhYhA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8377eef0274f7945be3b195ebb99398309a55826",
+        "rev": "c0e5d0b73afa8a826d1d5580b4e894fb16c035ff",
         "type": "github"
       },
       "original": {
@@ -107,6 +107,21 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-nix-unstable-20201205": {
+      "locked": {
+        "lastModified": 1613984754,
+        "narHash": "sha256-CGsiTsuRq0fWwWRzzn0a+MxO2EUJT3M3qt0/n9RUjMY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8377eef0274f7945be3b195ebb99398309a55826",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "8377eef0274f7945be3b195ebb99398309a55826",
+        "type": "indirect"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -115,7 +130,8 @@
         "nixpkgs-nix-2_2_2": "nixpkgs-nix-2_2_2",
         "nixpkgs-nix-2_3_10": "nixpkgs-nix-2_3_10",
         "nixpkgs-nix-2_3_7": "nixpkgs-nix-2_3_7",
-        "nixpkgs-nix-unstable-20200829": "nixpkgs-nix-unstable-20200829"
+        "nixpkgs-nix-unstable-20200829": "nixpkgs-nix-unstable-20200829",
+        "nixpkgs-nix-unstable-20201205": "nixpkgs-nix-unstable-20201205"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "nixpkgs/nixos-unstable-small";
+    nixpkgs-nix-unstable-20201205.url = "nixpkgs/8377eef0274f7945be3b195ebb99398309a55826";
     nixpkgs-nix-unstable-20200829.url = "nixpkgs/eb6e2ac2c033a86afa6a606753aab0dbde8bddda";
     nixpkgs-nix-2_3_10.url = "nixpkgs/31999436daf18dc4f98559304aa846613dd821bb";
     nixpkgs-nix-2_3_7.url = "nixpkgs/046427570ebe2726a2f21c3b51d84d29c86ebde5";
@@ -17,6 +18,7 @@
     self,
     flake-utils,
     nixpkgs,
+    nixpkgs-nix-unstable-20201205,
     nixpkgs-nix-unstable-20200829,
     nixpkgs-nix-2_3_10,
     nixpkgs-nix-2_3_7,
@@ -27,7 +29,6 @@
   in flake-utils.lib.eachSystem allSystems (system:
 
     let
-
       inherit (nixpkgs) lib;
 
       preferRemoteBuild = drv: drv.overrideAttrs (_: {
@@ -60,6 +61,7 @@
         nix.version (makeNixArchive nix)
       ) [
         pkgs.nixUnstable
+        nixpkgs-nix-unstable-20201205.legacyPackages.${system}.nixUnstable
         nixpkgs-nix-unstable-20200829.legacyPackages.${system}.nixUnstable
         nixpkgs-nix-2_3_10.legacyPackages.${system}.nix
         nixpkgs-nix-2_3_7.legacyPackages.${system}.nix


### PR DESCRIPTION
Update to the latest `nixUnstable` as some commands have changed syntax.