### PR TITLE
Use gtar to restore /nix on macOS

### DIFF
--- a/nix-quick-install.sh
+++ b/nix-quick-install.sh
@@ -44,21 +44,16 @@ else
   fi
 fi
 
-# Fetch nix archive
-rel="$(head -n1 "$RELEASE_FILE")"
-url="${NIX_ARCHIVES_URL:-https://github.com/nixbuild/nix-quick-install-action/releases/download/$rel}/nix-$NIX_VERSION-$sys.tar.zstd"
-archive="$(mktemp)"
-curl -sL --retry 3 --retry-connrefused "$url" | zstd -df - -o "$archive"
-
-# Unpack nix
+# Fetch and unpack nix archive
 if [[ "$sys" =~ .*-darwin ]]; then
   # MacOS tar doesn't have the --skip-old-files, so we use gtar
   tar=gtar
 else
   tar=tar
 fi
-$tar --skip-old-files --strip-components 1 -x -f "$archive" -C /nix
-rm -f "$archive"
+rel="$(head -n1 "$RELEASE_FILE")"
+url="${NIX_ARCHIVES_URL:-https://github.com/nixbuild/nix-quick-install-action/releases/download/$rel}/nix-$NIX_VERSION-$sys.tar.zstd"
+curl -sL --retry 3 --retry-connrefused "$url" | $tar --skip-old-files --strip-components 1 -x -I unzstd -C /nix
 
 # Setup nix.conf
 NIX_CONF_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/nix/nix.conf"

--- a/nix-quick-install.sh
+++ b/nix-quick-install.sh
@@ -52,13 +52,12 @@ curl -sL --retry 3 --retry-connrefused "$url" | zstd -df - -o "$archive"
 
 # Unpack nix
 if [[ "$sys" =~ .*-darwin ]]; then
-  # MacOS tar doesn't have the --skip-old-files, so we use rsync instead
-  tmpdir="$(mktemp -d)"
-  tar --keep-old-files --strip-components 1 -x -f "$archive" -C "$tmpdir"
-  rsync --archive --ignore-existing "$tmpdir/" /nix/
+  # MacOS tar doesn't have the --skip-old-files, so we use gtar
+  tar=gtar
 else
-  tar --skip-old-files --strip-components 1 -x -f "$archive" -C /nix
+  tar=tar
 fi
+$tar --skip-old-files --strip-components 1 -x -f "$archive" -C /nix
 rm -f "$archive"
 
 # Setup nix.conf


### PR DESCRIPTION
GNU tar is included in default Github runner macOS images https://github.com/actions/runner-images/blob/macOS-12/20231216.1/images/macos/macos-12-Readme.md

Use it to save a few seconds on macOS runner.