### PR TITLE
Optionally enable KVM on the runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,11 @@ inputs:
     description: |
       Don't use. For bootstrapping purposes only.
 
+  enable_kvm:
+    description: 'Enable KVM for hardware-accelerated virtualization on Linux, if available.'
+    required: false
+    default: true
+
 
 runs:
   using: "composite"
@@ -59,6 +64,7 @@ runs:
         NIX_ARCHIVES_URL: ${{ inputs.nix_archives_url }}
         NIX_ON_TMPFS: ${{ inputs.nix_on_tmpfs }}
         GITHUB_ACCESS_TOKEN: ${{ inputs.github_access_token }}
+        ENABLE_KVM: ${{ inputs.enable_kvm }}
 
 branding:
   icon: zap

--- a/nix-quick-install.sh
+++ b/nix-quick-install.sh
@@ -32,6 +32,16 @@ case "$OSTYPE" in
     exit 1
 esac
 
+# Enable KVM on Linux so NixOS tests can run quickly.
+# Do this early in the process so nix installation detects the KVM feature.
+enable_kvm() {
+  echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-install-nix-action-kvm.rules
+  sudo udevadm control --reload-rules && sudo udevadm trigger --name-match=kvm
+}
+if [[ ("$sys" =~ .*-linux) && ("$ENABLE_KVM" == 'true') ]]; then
+  enable_kvm && echo 'Enabled KVM' || echo 'KVM is not available'
+fi
+
 # Make sure /nix exists and is writeable
 if [ -a /nix ]; then
   if ! [ -w /nix ]; then


### PR DESCRIPTION
I switched to this action from [cachix/install-nix-action](https://github.com/cachix/install-nix-action), because I wanted to use [nix-community/cache-nix-action](https://github.com/nix-community/cache-nix-action), and suddenly my NixOS tests slowed waaaaay down. I had to do quite a bit of investigation to determine it was because `install-nix-action` has a step to enable KVM when it's available, and this action doesn't.

In order to save others the investigation, it would be great if `nix-quick-install-action` also had this functionality. It's basically the same logic as `install-nix-action`, but modified a bit for this repo's style.

I don't think this is a breaking change, and having KVM enabled for me without having to learn about it was nice. But we can make the new input default to `false` if maintainers prefer.

I have tested this change by running the logic inside the conditional in an action step preceding this one, and then running NixOS tests afterwards to confirm that KVM worked as expected.