### PR TITLE
Update flake inputs and support linux arm64

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,7 +15,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14]
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - macos-15
+          - macos-13
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -43,8 +47,9 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-22.04
-          - macos-14
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - macos-15
           - macos-13
         nix_version:
           - 2.26.1
@@ -77,8 +82,9 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-22.04
-          - macos-14
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - macos-15
           - macos-13
         nix_version:
           - 2.26.1
@@ -126,6 +132,10 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: nix-archives-Linux-X64
+          path: /tmp/archives
+      - uses: actions/download-artifact@v4
+        with:
+          name: nix-archives-Linux-ARM64
           path: /tmp/archives
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -23,10 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: ./
-        with:
-          nix_archives_url: https://github.com/nixbuild/nix-quick-install-action/releases/download/v29
-          nix_version: 2.24.9
+      - uses: cachix/install-nix-action@v30
       - uses: cachix/cachix-action@v15
         with:
           name: nixbuild

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -52,7 +52,6 @@ jobs:
           - 2.26.1
           - 2.25.5
           - 2.24.12
-          - 2.3.18
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -87,7 +86,6 @@ jobs:
           - 2.26.1
           - 2.25.5
           - 2.24.12
-          - 2.3.18
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -47,13 +47,9 @@ jobs:
           - macos-14
           - macos-13
         nix_version:
-          - 2.24.9
-          - 2.23.3
-          - 2.22.3
-          - 2.21.4
-          - 2.20.8
-          - 2.19.6
-          - 2.18.8
+          - 2.26.1
+          - 2.25.5
+          - 2.24.12
           - 2.3.18
     runs-on: ${{ matrix.os }}
     steps:
@@ -85,13 +81,9 @@ jobs:
           - macos-14
           - macos-13
         nix_version:
-          - 2.24.9
-          - 2.23.3
-          - 2.22.3
-          - 2.21.4
-          - 2.20.8
-          - 2.19.6
-          - 2.18.8
+          - 2.26.1
+          - 2.25.5
+          - 2.24.12
           - 2.3.18
     runs-on: ${{ matrix.os }}
     steps:
@@ -146,7 +138,7 @@ jobs:
       - uses: ./
         with:
           nix_archives_url: file:///tmp/archives
-          nix_version: 2.24.9
+          nix_version: 2.24.12
       - uses: cachix/cachix-action@v15
         with:
           name: nixbuild

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-24.04
+          - ubuntu-22.04
           - ubuntu-24.04-arm
           - macos-15
           - macos-13
@@ -44,7 +44,7 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-24.04
+          - ubuntu-22.04
           - ubuntu-24.04-arm
           - macos-15
           - macos-13
@@ -79,7 +79,7 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-24.04
+          - ubuntu-22.04
           - ubuntu-24.04-arm
           - macos-15
           - macos-13

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ jobs:
   minimal:
     runs-on: ubuntu-latest
     steps:
-      - uses: nixbuild/nix-quick-install-action@v29
+      - uses: nixbuild/nix-quick-install-action@v30
       - run: nix build --version
       - run: nix build ./examples/flakes-simple
       - name: hello
@@ -112,17 +112,17 @@ Build a specific version of Nix like this (requires you to use a version of Nix
 that supports flakes):
 
 ```
-$ nix build github:nixbuild/nix-quick-install-action#nix-2_3_16
+$ nix build github:nixbuild/nix-quick-install-action#nix-2_26_1
 
 $ ./result/bin/nix --version
-nix (Nix) 2.3.16
+nix (Nix) 2.26.1
 ```
 
 With `nix shell -c` you can also directly run Nix like this:
 
 ```
-$ nix shell github:nixbuild/nix-quick-install-action#nix-2_2_2 -c nix --version
-nix (Nix) 2.2.2
+$ nix shell github:nixbuild/nix-quick-install-action#nix-2_26_1 -c nix --version
+nix (Nix) 2.26.1
 ```
 
 List all available Nix versions like this:
@@ -186,7 +186,7 @@ been removed in the latest revision of `nix-quick-install-action`, you can
 specify a specific release of `nix-quick-install-action` like this:
 
 ```
-$ nix build github:nixbuild/nix-quick-install-action/v12#nix-2_3_7
+$ nix build github:nixbuild/nix-quick-install-action/v29#nix-2_24_9
 ```
 
 Note that we've added `/v12` to the flake url above.

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
 
   nix_version:
     required: true
-    default: "2.24.9"
+    default: "2.24.12"
     description: |
       The version of Nix that should be installed
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1600209923,
-        "narHash": "sha256-zoOWauTliFEjI++esk6Jzk7QO5EKpddWXQm9yQK24iM=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cd06d3c1df6879c9e41cb2c33113df10566c760",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -17,23 +20,39 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1729265718,
-        "narHash": "sha256-4HQI+6LsO3kpWTYuVGIzhJs1cetFcwT7quWCk/6rqeo=",
-        "owner": "NixOS",
+        "lastModified": 1739863612,
+        "narHash": "sha256-UbtgxplOhFcyjBcNbTVO8+HUHAl/WXFDOb6LvqShiZo=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ccc0c2126893dd20963580b6478d1a10a4512185",
+        "rev": "632f04521e847173c54fa72973ec6c39a371211c",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "rev": "ccc0c2126893dd20963580b6478d1a10a4512185",
-        "type": "indirect"
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "632f04521e847173c54fa72973ec6c39a371211c",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs-unstable": "nixpkgs-unstable"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs-unstable.url = "nixpkgs/ccc0c2126893dd20963580b6478d1a10a4512185";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/632f04521e847173c54fa72973ec6c39a371211c";
   };
 
   nixConfig = {

--- a/flake.nix
+++ b/flake.nix
@@ -53,10 +53,9 @@
         nix.version nix
       ) (
         [
-          nixpkgs-unstable.legacyPackages.${system}.nixVersions.latest
           nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_26
+          nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_25
           nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_24
-          nixpkgs-unstable.legacyPackages.${system}.nixVersions.minimum
         ]
       ));
 

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     flake-utils,
     nixpkgs-unstable,
   }:
-  let allSystems = [ "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
+  let allSystems = [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
   in flake-utils.lib.eachSystem allSystems (system:
 
     let

--- a/flake.nix
+++ b/flake.nix
@@ -54,12 +54,8 @@
       ) (
         [
           nixpkgs-unstable.legacyPackages.${system}.nixVersions.latest
-          nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_23
-          nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_22
-          nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_21
-          nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_20
-          nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_19
-          nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_18
+          nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_26
+          nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_24
           nixpkgs-unstable.legacyPackages.${system}.nixVersions.minimum
         ]
       ));


### PR DESCRIPTION
- Updated `nixpkgs` to the latest `nixpkgs/unstable`
- Updated `flake-utils` to the latest version
- Updated nix versions (some old versions were dropped https://github.com/NixOS/nixpkgs/pull/354148, https://github.com/NixOS/nixpkgs/pull/359024)
- Added linux arm64 in the flake.nix and in ci (https://github.com/nixbuild/nix-quick-install-action/issues/55).