### PR TITLE
Add Lix support

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           name: nixbuild
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+      - name: Fix Lix tests
+        if: matrix.os == 'ubuntu-24.04-arm'
+        run: |
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_unconfined=0
       - name: Build nix archives
         id: build-nix-archives
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -56,14 +56,26 @@ jobs:
           - ubuntu-24.04-arm
           - macos-15
           - macos-13
-        nix_version:
-          - 2.3.18
-          - 2.26.1
-          - 2.25.5
-          - 2.24.12
+        nix:
+          - version : 2.92.0
+            impl: lix
+          - version : 2.91.1
+            impl: lix
+          - version : 2.90.0
+            impl: lix
+          - version: 2.3.18
+            impl: nix
+          - version: 2.26.1
+            impl: nix
+          - version: 2.25.5
+            impl: nix
+          - version: 2.24.12
+            impl: nix
         exclude:
           - os: ubuntu-24.04-arm
-            nix_version: 2.3.18
+            nix:
+              version: 2.3.18
+              impl: nix
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +86,8 @@ jobs:
       - uses: ./
         with:
           nix_archives_url: file://${{steps.nix-archives.outputs.download-path}}
-          nix_version: ${{ matrix.nix_version }}
+          nix_version: ${{ matrix.nix.version }}
+          nix_implementation: ${{ matrix.nix.impl }}
           nix_on_tmpfs: true
       - name: Test nix
         run: nix-build -v --version
@@ -94,14 +107,26 @@ jobs:
           - ubuntu-24.04-arm
           - macos-15
           - macos-13
-        nix_version:
-          - 2.3.18
-          - 2.26.1
-          - 2.25.5
-          - 2.24.12
+        nix:
+          - version : 2.92.0
+            impl: lix
+          - version : 2.91.1
+            impl: lix
+          - version : 2.90.0
+            impl: lix
+          - version: 2.3.18
+            impl: nix
+          - version: 2.26.1
+            impl: nix
+          - version: 2.25.5
+            impl: nix
+          - version: 2.24.12
+            impl: nix
         exclude:
           - os: ubuntu-24.04-arm
-            nix_version: 2.3.18
+            nix:
+              version: 2.3.18
+              impl: nix
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -112,7 +137,8 @@ jobs:
       - uses: ./
         with:
           nix_archives_url: file://${{steps.nix-archives.outputs.download-path}}
-          nix_version: ${{ matrix.nix_version }}
+          nix_version: ${{ matrix.nix.version }}
+          nix_implementation: ${{ matrix.nix.impl }}
           nix_conf: ${{ matrix.nix_conf }}
       - uses: cachix/cachix-action@v15
         with:

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,16 @@ inputs:
       supported by the version of nix-quick-install-action you're using by
       going to https://github.com/nixbuild/nix-quick-install-action/releases
 
+  nix_implementation:
+    required: false
+    default: "nix"
+    description: |
+      The implementation of Nix to be used.
+
+      Supported implementations:
+      - nix (default): https://nixos.org/
+      - lix: https://lix.systems/
+
   nix_conf:
     required: false
     description: |
@@ -59,6 +69,7 @@ runs:
       shell: bash
       env:
         RELEASE_FILE: ${{ github.action_path }}/RELEASE
+        NIX_IMPLEMENTATION: ${{ inputs.nix_implementation }}
         NIX_VERSION: ${{ inputs.nix_version }}
         NIX_CONF: ${{ inputs.nix_conf }}
         NIX_ARCHIVES_URL: ${{ inputs.nix_archives_url }}

--- a/flake.lock
+++ b/flake.lock
@@ -16,38 +16,6 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -66,7 +34,7 @@
         "type": "github"
       }
     },
-    "lix-2_90": {
+    "lix-2_92": {
       "inputs": {
         "flake-compat": "flake-compat",
         "nix2container": "nix2container",
@@ -75,50 +43,6 @@
         ],
         "nixpkgs-regression": "nixpkgs-regression",
         "pre-commit-hooks": "pre-commit-hooks"
-      },
-      "locked": {
-        "lastModified": 1720626042,
-        "narHash": "sha256-f8k+BezKdJfmE+k7zgBJiohtS3VkkriycdXYsKOm3sc=",
-        "rev": "2a4376be20d70feaa2b0e640c5041fb66ddc67ed",
-        "type": "tarball",
-        "url": "https://git.lix.systems/api/v1/repos/lix-project/lix/archive/2a4376be20d70feaa2b0e640c5041fb66ddc67ed.tar.gz?rev=2a4376be20d70feaa2b0e640c5041fb66ddc67ed"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://git.lix.systems/lix-project/lix/archive/2.90.0.tar.gz"
-      }
-    },
-    "lix-2_91": {
-      "inputs": {
-        "flake-compat": "flake-compat_2",
-        "nix2container": "nix2container_2",
-        "nixpkgs": [
-          "nixpkgs-unstable"
-        ],
-        "nixpkgs-regression": "nixpkgs-regression_2",
-        "pre-commit-hooks": "pre-commit-hooks_2"
-      },
-      "locked": {
-        "lastModified": 1729298361,
-        "narHash": "sha256-hiGtfzxFkDc9TSYsb96Whg0vnqBVV7CUxyscZNhed0U=",
-        "rev": "ad9d06f7838a25beec425ff406fe68721fef73be",
-        "type": "tarball",
-        "url": "https://git.lix.systems/api/v1/repos/lix-project/lix/archive/ad9d06f7838a25beec425ff406fe68721fef73be.tar.gz?rev=ad9d06f7838a25beec425ff406fe68721fef73be"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://git.lix.systems/lix-project/lix/archive/2.91.1.tar.gz"
-      }
-    },
-    "lix-2_92": {
-      "inputs": {
-        "flake-compat": "flake-compat_3",
-        "nix2container": "nix2container_3",
-        "nixpkgs": [
-          "nixpkgs-unstable"
-        ],
-        "nixpkgs-regression": "nixpkgs-regression_3",
-        "pre-commit-hooks": "pre-commit-hooks_3"
       },
       "locked": {
         "lastModified": 1737234286,
@@ -135,38 +59,6 @@
     "nix2container": {
       "flake": false,
       "locked": {
-        "lastModified": 1712990762,
-        "narHash": "sha256-hO9W3w7NcnYeX8u8cleHiSpK2YJo7ecarFTUlbybl7k=",
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "rev": "20aad300c925639d5d6cbe30013c8357ce9f2a2e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "type": "github"
-      }
-    },
-    "nix2container_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1720642556,
-        "narHash": "sha256-qsnqk13UmREKmRT7c8hEnz26X3GFFyIQrqx4EaRc1Is=",
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "rev": "3853e5caf9ad24103b13aa6e0e8bcebb47649fe4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nlewo",
-        "repo": "nix2container",
-        "type": "github"
-      }
-    },
-    "nix2container_3": {
-      "flake": false,
-      "locked": {
         "lastModified": 1724996935,
         "narHash": "sha256-njRK9vvZ1JJsP8oV2OgkBrpJhgQezI03S7gzskCcHos=",
         "owner": "nlewo",
@@ -181,38 +73,6 @@
       }
     },
     "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression_2": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression_3": {
       "locked": {
         "lastModified": 1643052045,
         "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
@@ -247,38 +107,6 @@
     "pre-commit-hooks": {
       "flake": false,
       "locked": {
-        "lastModified": 1712055707,
-        "narHash": "sha256-4XLvuSIDZJGS17xEwSrNuJLL7UjDYKGJSbK1WWX2AK8=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "e35aed5fda3cc79f88ed7f1795021e559582093a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1721042469,
-        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks_3": {
-      "flake": false,
-      "locked": {
         "lastModified": 1733318908,
         "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
         "owner": "cachix",
@@ -295,8 +123,6 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "lix-2_90": "lix-2_90",
-        "lix-2_91": "lix-2_91",
         "lix-2_92": "lix-2_92",
         "nixpkgs-unstable": "nixpkgs-unstable"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,53 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -15,6 +63,168 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "lix-2_90": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nix2container": "nix2container",
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-regression": "nixpkgs-regression",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1720626042,
+        "narHash": "sha256-f8k+BezKdJfmE+k7zgBJiohtS3VkkriycdXYsKOm3sc=",
+        "rev": "2a4376be20d70feaa2b0e640c5041fb66ddc67ed",
+        "type": "tarball",
+        "url": "https://git.lix.systems/api/v1/repos/lix-project/lix/archive/2a4376be20d70feaa2b0e640c5041fb66ddc67ed.tar.gz?rev=2a4376be20d70feaa2b0e640c5041fb66ddc67ed"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://git.lix.systems/lix-project/lix/archive/2.90.0.tar.gz"
+      }
+    },
+    "lix-2_91": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "nix2container": "nix2container_2",
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-regression": "nixpkgs-regression_2",
+        "pre-commit-hooks": "pre-commit-hooks_2"
+      },
+      "locked": {
+        "lastModified": 1729298361,
+        "narHash": "sha256-hiGtfzxFkDc9TSYsb96Whg0vnqBVV7CUxyscZNhed0U=",
+        "rev": "ad9d06f7838a25beec425ff406fe68721fef73be",
+        "type": "tarball",
+        "url": "https://git.lix.systems/api/v1/repos/lix-project/lix/archive/ad9d06f7838a25beec425ff406fe68721fef73be.tar.gz?rev=ad9d06f7838a25beec425ff406fe68721fef73be"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://git.lix.systems/lix-project/lix/archive/2.91.1.tar.gz"
+      }
+    },
+    "lix-2_92": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "nix2container": "nix2container_3",
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-regression": "nixpkgs-regression_3",
+        "pre-commit-hooks": "pre-commit-hooks_3"
+      },
+      "locked": {
+        "lastModified": 1737234286,
+        "narHash": "sha256-CCKIAE84dzkrnlxJCKFyffAxP3yfsOAbdvydUGqq24g=",
+        "rev": "2837da71ec1588c1187d2e554719b15904a46c8b",
+        "type": "tarball",
+        "url": "https://git.lix.systems/api/v1/repos/lix-project/lix/archive/2837da71ec1588c1187d2e554719b15904a46c8b.tar.gz?rev=2837da71ec1588c1187d2e554719b15904a46c8b"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://git.lix.systems/lix-project/lix/archive/2.92.0.tar.gz"
+      }
+    },
+    "nix2container": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1712990762,
+        "narHash": "sha256-hO9W3w7NcnYeX8u8cleHiSpK2YJo7ecarFTUlbybl7k=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "20aad300c925639d5d6cbe30013c8357ce9f2a2e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "nix2container_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1720642556,
+        "narHash": "sha256-qsnqk13UmREKmRT7c8hEnz26X3GFFyIQrqx4EaRc1Is=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "3853e5caf9ad24103b13aa6e0e8bcebb47649fe4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "nix2container_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1724996935,
+        "narHash": "sha256-njRK9vvZ1JJsP8oV2OgkBrpJhgQezI03S7gzskCcHos=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "fa6bb0a1159f55d071ba99331355955ae30b3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression_2": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression_3": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
         "type": "github"
       }
     },
@@ -34,9 +244,60 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1712055707,
+        "narHash": "sha256-4XLvuSIDZJGS17xEwSrNuJLL7UjDYKGJSbK1WWX2AK8=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "e35aed5fda3cc79f88ed7f1795021e559582093a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1721042469,
+        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733318908,
+        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "lix-2_90": "lix-2_90",
+        "lix-2_91": "lix-2_91",
+        "lix-2_92": "lix-2_92",
         "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -87,12 +87,16 @@
           nixpkgs-unstable.legacyPackages.${system}.nixVersions.minimum
         ]
       );
-      lixVersions = mkVersions
+      lixVersions = mkVersions (
         [
           lix-2_92.packages.${system}.nix
           lix-2_91.packages.${system}.nix
+        ] ++
+        lib.optionals (system != "aarch64-darwin")
+        [
           lix-2_90.packages.${system}.nix
-        ];
+        ]
+      );
 
       nixPackages = mkPackages "nix" nixVersions;
       lixPackages = mkPackages "lix" lixVersions;

--- a/flake.nix
+++ b/flake.nix
@@ -9,14 +9,6 @@
       url = "https://git.lix.systems/lix-project/lix/archive/2.92.0.tar.gz";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
-    lix-2_91 = {
-      url = "https://git.lix.systems/lix-project/lix/archive/2.91.1.tar.gz";
-      inputs.nixpkgs.follows = "nixpkgs-unstable";
-    };
-    lix-2_90 = {
-      url = "https://git.lix.systems/lix-project/lix/archive/2.90.0.tar.gz";
-      inputs.nixpkgs.follows = "nixpkgs-unstable";
-    };
   };
 
   nixConfig = {
@@ -31,8 +23,6 @@
     nixpkgs-unstable,
 
     lix-2_92,
-    lix-2_91,
-    lix-2_90,
   }:
   let allSystems = [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
   in flake-utils.lib.eachSystem allSystems (system:
@@ -87,16 +77,12 @@
           nixpkgs-unstable.legacyPackages.${system}.nixVersions.minimum
         ]
       );
-      lixVersions = mkVersions (
+      lixVersions = mkVersions
         [
           lix-2_92.packages.${system}.nix
-          lix-2_91.packages.${system}.nix
-        ] ++
-        lib.optionals (system != "aarch64-darwin")
-        [
-          lix-2_90.packages.${system}.nix
-        ]
-      );
+          nixpkgs-unstable.legacyPackages.${system}.lixVersions.lix_2_91
+          nixpkgs-unstable.legacyPackages.${system}.lixVersions.lix_2_90
+        ];
 
       nixPackages = mkPackages "nix" nixVersions;
       lixPackages = mkPackages "lix" lixVersions;

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
 
       mkVersions = packages: system: lib.listToAttrs (map (nix: lib.nameValuePair
         nix.version nix
-      ) packages);
+      ) (packages system));
 
       mkPackages = name: versions: lib.mapAttrs'
         (v: p: lib.nameValuePair "${name}-${lib.replaceStrings ["."] ["_"] v}" p)
@@ -66,7 +66,7 @@
 
       mkArchives = name: versions: system: lib.mapAttrs (_: makeNixArchive name) (versions system);
 
-      nixVersions = mkVersions (
+      nixVersions = mkVersions (system:
         [
           nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_26
           nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_25
@@ -77,12 +77,13 @@
           nixpkgs-unstable.legacyPackages.${system}.nixVersions.minimum
         ]
       );
-      lixVersions = mkVersions
+      lixVersions = mkVersions (system:
         [
           lix-2_92.packages.${system}.nix
           nixpkgs-unstable.legacyPackages.${system}.lixVersions.lix_2_91
           nixpkgs-unstable.legacyPackages.${system}.lixVersions.lix_2_90
-        ];
+        ]
+      );
 
       nixPackages = mkPackages "nix" nixVersions;
       lixPackages = mkPackages "lix" lixVersions;

--- a/flake.nix
+++ b/flake.nix
@@ -94,6 +94,7 @@
       mkAllArchives = name: archives: lib.concatMap (system:
         map (version: {
           inherit system version;
+          impl = name;
           fileName = "${name}-${version}-${system}.tar.zstd";
         }) (lib.attrNames (archives system))
       ) allSystems;
@@ -154,8 +155,8 @@
 
             echo >&2 "New release: $prev_release -> $release"
             gh release create "$release" ${
-              lib.concatMapStringsSep " " ({ system, version, fileName }:
-                ''"$nix_archives/${fileName}#nix-${version}-${system}"''
+              lib.concatMapStringsSep " " ({ system, version, impl, fileName }:
+                ''"$nix_archives/${fileName}#${impl}-${version}-${system}"''
               ) allArchives
             } \
               --title "$GITHUB_REPOSITORY@$release" \

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,19 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/632f04521e847173c54fa72973ec6c39a371211c";
+
+    lix-2_92 = {
+      url = "https://git.lix.systems/lix-project/lix/archive/2.92.0.tar.gz";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
+    lix-2_91 = {
+      url = "https://git.lix.systems/lix-project/lix/archive/2.91.1.tar.gz";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
+    lix-2_90 = {
+      url = "https://git.lix.systems/lix-project/lix/archive/2.90.0.tar.gz";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
   };
 
   nixConfig = {
@@ -16,6 +29,10 @@
     self,
     flake-utils,
     nixpkgs-unstable,
+
+    lix-2_92,
+    lix-2_91,
+    lix-2_90,
   }:
   let allSystems = [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
   in flake-utils.lib.eachSystem allSystems (system:
@@ -56,6 +73,9 @@
           nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_26
           nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_25
           nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_24
+          lix-2_92.packages.${system}.nix
+          lix-2_91.packages.${system}.nix
+          lix-2_90.packages.${system}.nix
         ] ++
         lib.optionals (system != "aarch64-linux")
         [

--- a/nix-quick-install.sh
+++ b/nix-quick-install.sh
@@ -78,7 +78,7 @@ else
   tar=tar
 fi
 rel="$(head -n1 "$RELEASE_FILE")"
-url="${NIX_ARCHIVES_URL:-https://github.com/nixbuild/nix-quick-install-action/releases/download/$rel}/nix-$NIX_VERSION-$sys.tar.zstd"
+url="${NIX_ARCHIVES_URL:-https://github.com/nixbuild/nix-quick-install-action/releases/download/$rel}/$NIX_IMPLEMENTATION-$NIX_VERSION-$sys.tar.zstd"
 
 echo >&2 "Fetching nix archives from $url"
 case "$url" in


### PR DESCRIPTION
This PR introduces support for using nix-quick-install-action to install [Lix](https://lix.systems/), a fork of Nix.

## Interface
A new input `nix_implementation` has been added to choose the implementation of Nix the user wants to install - either `nix` for upstream Nix or `lix` for Lix. It defaults to `nix`, to keep compatibility with existing setups.

Lix versions are not the same as Nix ones, so if `lix` is specified, the user will also have to set `nix_version` explicitly to a supported version of Lix.

## Supported versions
The versions of Lix that can be passed to the action are currently:
- 2.92.0 (latest)
- 2.91.1
- 2.90.0

All 3 of these versions work across all supported systems.

## Notes
- While [2.92.0 is a stable release](https://lix.systems/blog/2025-01-18-lix-2.92-release/), it [hasn't landed in nixpkgs yet](https://github.com/NixOS/nixpkgs/pull/375030). In the interim, the build job in the CI is setup to build Lix from the 2.92.0 sources. This works, but does incur extra build time in CI on a cold cache.
- The "Fix Lix tests" step in the build job fixes an issue where the Lix tests fail in the aarch64-linux runner (and hence failing to build). As far as I understand, this is not an issue with aarch64-linux as a platform, but rather with [Ubuntu 23.10 as a distribution](https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces). If the x86_64-linux runner is updated to use Ubuntu 24.04 at some point, it's likely the same fix will be required there.
- I'm aware this is a fairly large change with non-negligible maintenance involved. I'm more than happy to keep maintaining this feature in a fork if this isn't a change you're interested in accepting, but I've sent it through in case it's something you'd be interested in having upstream.