### PR TITLE
Add Nix 2.28 / Remove deprecated versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,16 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1739863612,
-        "narHash": "sha256-UbtgxplOhFcyjBcNbTVO8+HUHAl/WXFDOb6LvqShiZo=",
+        "lastModified": 1747744144,
+        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "632f04521e847173c54fa72973ec6c39a371211c",
+        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "632f04521e847173c54fa72973ec6c39a371211c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/632f04521e847173c54fa72973ec6c39a371211c";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs";
   };
 
   nixConfig = {
@@ -53,8 +53,8 @@
         nix.version nix
       ) (
         [
+          nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_28
           nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_26
-          nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_25
           nixpkgs-unstable.legacyPackages.${system}.nixVersions.nix_2_24
         ] ++
         lib.optionals (system != "aarch64-linux")


### PR DESCRIPTION
This PR updates nixpkgs, adds the latest version `2.28`, and removes unsupported versions.
`2.27` is already deprecated so this PR ignores its version.