### PR TITLE
Authentication for private Github repo if fetchGit is used

### DIFF
--- a/nix-quick-install.sh
+++ b/nix-quick-install.sh
@@ -103,6 +103,12 @@ fi
 if [[ -n "${GITHUB_ACCESS_TOKEN:-}" ]]; then
   echo >>"$NIX_CONF_FILE" \
     "access-tokens = github.com=$GITHUB_ACCESS_TOKEN"
+
+  # Also write github token to .netrc so builtins.fetchGit (use git and git auth)
+  # can authenticate against private GitHub repos over HTTPS.
+  NETRC_FILE="$HOME/.netrc"
+  echo -e "machine github.com\nlogin github-token\npassword $GITHUB_ACCESS_TOKEN" >> "$NETRC_FILE"
+  chmod 600 "$NETRC_FILE"
 fi
 
 # Setup Flakes


### PR DESCRIPTION
`builtins.fetchGit` relies on the system `git` command and its authentication mechanisms, and does not make use of nix `access-tokens`. This can lead to issues when fetching private GitHub repositories in Nix builds.

In this PR, if the user has set `github_access_token`, it is also added to a `.netrc `file. This allows `fetchGit` to authenticate properly and work as expected with private repositories.

**Motivation**
We encountered this issue while building a python project using uv2nix, where a Python dependency was sourced from a private Git repository. `uv2nix` use `fetchGit` to fetch git repos which failed due to missing authentication:

https://github.com/pyproject-nix/uv2nix/blob/5707df99097375896a3dda811d492a2fabe63500/lib/build.nix#L348

While using fetchGithub is generally recommended and likely more common, fetchGit is still used in some cases, and the current behavior can be surprising when private repositories are involved.

Discussion

It’s understandable if this is not considered the right place to handle Git authentication, and that such setup could be managed outside of Nix.

However, including this behavior in Nix provides a better out-of-the-box experience: users who configure `github_access_token` will get the expected behavior, and builds involving private repositories will work without additional setup.